### PR TITLE
add read_visium mention to spatial tutorial

### DIFF
--- a/analysis-visualization-spatial.ipynb
+++ b/analysis-visualization-spatial.ipynb
@@ -62,7 +62,9 @@
     "\n",
     "We will use a **Visium** spatial transcriptomics dataset of the human lymphnode, which is publicly available from the 10x genomics website: [link](https://support.10xgenomics.com/spatial-gene-expression/datasets/1.0.0/V1_Human_Lymph_Node)\n",
     "\n",
-    "The function `datasets.visium_sge()` downloads the dataset from 10x genomics and returns an AnnData object that contains counts, images and spatial coordinates. We will calculate standards QC metrics with `pp.calculate_qc_metrics` and percentage of mitochondrial read counts per sample."
+    "The function `datasets.visium_sge()` downloads the dataset from 10x genomics and returns an AnnData object that contains counts, images and spatial coordinates. We will calculate standards QC metrics with `pp.calculate_qc_metrics` and percentage of mitochondrial read counts per sample.\n",
+    "\n",
+    "When using your own Visium data, use Scanpy's [`read_visium()`](https://icb-scanpy.readthedocs-hosted.com/en/latest/api/scanpy.read_visium.html) function to import it."
    ]
   },
   {


### PR DESCRIPTION
Thanks for adding spatial support to Scanpy.

Added an extra line to the data import bit of the tutorial that points readers to your `read_visium()` function. I didn't know how to actually import my own data when reading the tutorial, and I ended up having to go into the `datasets` source code to find out how you load it, so seems like it would be handy for future readers.